### PR TITLE
Update ilo_api_temp.py

### DIFF
--- a/check plugins 2.0/hpe_ilo/agent_based/ilo_api_temp.py
+++ b/check plugins 2.0/hpe_ilo/agent_based/ilo_api_temp.py
@@ -54,6 +54,7 @@ default_chassis_temperature_parameters = TempParamDict(
 hp_proliant_status2cmk_map = {
     "unknown": 3,
     "other": 3,
+    "none": 3,
     "ok": 0,
     "degraded": 2,
     "failed": 2,


### PR DESCRIPTION
status can be "none" on server restarts. This would cause a crash in CMK with "Key Error (none)".