### PR TITLE
Fix ilo_api_mem.py

### DIFF
--- a/check plugins 2.0/hpe_ilo/agent_based/ilo_api_mem.py
+++ b/check plugins 2.0/hpe_ilo/agent_based/ilo_api_mem.py
@@ -46,14 +46,14 @@ def discovery_ilo_api_mem(section) -> DiscoveryResult:
 def check_ilo_api_mem(item: str, section) -> CheckResult:
     data = section.get(item)
     if data:
-        if data[3] == "GoodInUse" or "OK":
+        if data[3] == "GoodInUse" or data[3] == "OK":
             yield Result(
                 state=State(0),
                 summary="Operational state OK - Type %s - Size %s MB" %
                 (data[1], data[2]))
         else:
             yield Result(state=State(2),
-                         summary="Error in Modul %s with Status %s" %
+                         summary="Error in Module %s with Status %s" %
                          (data[0], data[3]))
 
 


### PR DESCRIPTION
Plugin fails to detect warning state in module; fixed syntax. 

    Python 3.10.6 (main, Nov 14 2022, 16:10:14) [GCC 11.3.0] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> health="Warning"
    >>> if health == "Good" or "OK":
    ...   print ("strange")
    ...
    strange
    >>>