### PR TITLE
Compatibility fix for CheckMK v2.2.x

### DIFF
--- a/check plugins 2.0/dell_idrac_redfish/checks/agent_dell_idrac
+++ b/check plugins 2.0/dell_idrac_redfish/checks/agent_dell_idrac
@@ -14,15 +14,16 @@
 # to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
 # Boston, MA 02110-1301 USA.
 
+import shlex
 
 def agent_dell_idrac_arguments(params, hostname, ipaddress):
     args = ""
     if params["user"] != "":
-        args += " -u " + quote_shell_string(params["user"])
+        args += " -u " + shlex.quote(params["user"])
     if params["password"] != "":
-        args += " -p " + quote_shell_string(params["password"])
+        args += " -p " + shlex.quote(params["password"])
 
-    args += " %s " % quote_shell_string(ipaddress)
+    args += " %s " % shlex.quote(ipaddress)
     return args
 
 


### PR DESCRIPTION
Replaced deprecated 'quote_shell_string' function by shlex.quote
https://github.com/Checkmk/checkmk/commit/3c746adca4da525a13f2a9ce02ee2a64e238f92f