### PR TITLE
Added possibility to ignore Prism VM state via WATO rule.

### DIFF
--- a/check plugins 2.1/nutanix/agent_based/prism_vms.py
+++ b/check plugins 2.1/nutanix/agent_based/prism_vms.py
@@ -57,7 +57,7 @@ def check_prism_vms(item: str, params: Mapping[str, Any], section: Section) -> C
     prot_domain = data["protectionDomainName"]
     host_name = data["hostName"]
     memory = render.bytes(data["memoryCapacityInBytes"])
-    if wanted_state == state_text.lower():
+    if wanted_state == state_text.lower() or wanted_state == "ignore":
         state = 0
     else:
         state = state_value

--- a/check plugins 2.1/nutanix/web/plugins/wato/prism_vms.py
+++ b/check plugins 2.1/nutanix/web/plugins/wato/prism_vms.py
@@ -38,6 +38,7 @@ def _parameters_valuespec_prism_vms():
         ("resuming", _("Resuming")),
         ("resetting", _("Resetting")),
         ("migrating", _("Migrating")),
+        ("ignore", _("Ignore")),
     ]
     return Dictionary(
         elements=[


### PR DESCRIPTION
Hi Andreas,
nur 2 kleine Änderungen, die die Möglichkeit schaffen VM-States aus dem Prism über die "Wanted VM State"-Regel zu ignorieren.

Gruß Jeronimo