### PR TITLE
ignore NICs and/or ports that have a state of offline

### DIFF
--- a/check plugins 2.2/redfish/agent_based/redfish_ethernetinterfaces.py
+++ b/check plugins 2.2/redfish/agent_based/redfish_ethernetinterfaces.py
@@ -42,7 +42,7 @@ def discovery_redfish_ethernetinterfaces(section) -> DiscoveryResult:
     for key in section.keys():
         if not section[key].get("Status"):
             continue
-        if section[key].get("Status", {}).get("State") in ["Absent", "Disabled"]:
+        if section[key].get("Status", {}).get("State") in ["Absent", "Disabled", "Offline"]:
             continue
         yield Service(item=section[key]["Id"])
 

--- a/check plugins 2.2/redfish/agent_based/redfish_networkadapters.py
+++ b/check plugins 2.2/redfish/agent_based/redfish_networkadapters.py
@@ -40,7 +40,7 @@ register.agent_section(
 
 def discovery_redfish_networkadapters(section) -> DiscoveryResult:
     for key in section.keys():
-        if section[key].get("Status", {}).get("State") in ["Absent", "Disabled"]:
+        if section[key].get("Status", {}).get("State") in ["Absent", "Disabled", "Offline"]:
             continue
         yield Service(item=section[key]["Id"])
 


### PR DESCRIPTION
In case that a server has unconnected NIC ports these appear as "offline". Subsequent check will therefore fail, e.g. link state and speed. This PR adds an additional check during discovery to ignore such ports.