### PR TITLE
Fix typo in rule

### DIFF
--- a/check plugins 2.3/win_firewall_status/readme.md
+++ b/check plugins 2.3/win_firewall_status/readme.md
@@ -5,3 +5,4 @@ The plugin outputs the configured firewall status and with the check rules you c
 2.2.0 - migrated to CMK 2.2 with some smaller fixes (typos and so on)
 2.3.0 - CMK 2.3 ready
 2.3.1 - small bug in bakery fixed
+2.3.2 - fix typo in rule

--- a/check plugins 2.3/win_firewall_status/web/plugins/wato/win_firewall_status.py
+++ b/check plugins 2.3/win_firewall_status/web/plugins/wato/win_firewall_status.py
@@ -22,7 +22,7 @@ from cmk.gui.plugins.wato.utils import (
 
 def _parameter_valuespec_win_firewall_status():
     return Dictionary(
-        title=_("Time left for installed certificates before renew."),
+        title=_("Firewall Profile configuration"),
         elements=[
             (
                 "profiles",


### PR DESCRIPTION
There was a typo in the service monitoring rule, which looked like a copy/paste error. This is fixed now.