### PR TITLE
redfish_drives: Handle missing value due to drive failure

### DIFF
--- a/check plugins 2.3/redfish/cmk_plugins/redfish/agent_based/redfish_drives.py
+++ b/check plugins 2.3/redfish/cmk_plugins/redfish/agent_based/redfish_drives.py
@@ -38,7 +38,7 @@ def check_redfish_drives(item: str, section: RedfishAPIData) -> CheckResult:
         return
 
     disc_msg = (
-        f"Size: {data.get('CapacityBytes', 0) / 1024 / 1024 / 1024:0.0f}GB, "
+        f"Size: {(data.get('CapacityBytes', 0) or 0) / 1024 / 1024 / 1024:0.0f}GB, "
         f"Speed {data.get('CapableSpeedGbs', 0)} Gbs"
     )
 


### PR DESCRIPTION
Drives that experience failure may report certain values as `null` via the Redfish API. If the reported capacity is affected, this led to a crash in the "Drive" service:
```
TypeError (unsupported operand type(s) for /: 'NoneType' and 'int')
```

Now the `null` capacity values are treated the same as completely missing capacity: The reported drive size is 0GB.